### PR TITLE
feat: ブランチデプロイメント機能の実装

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -4,10 +4,21 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Deploy if: push to main OR (PR and (not dependabot OR has deploy-preview label))
+    if: |
+      github.event_name == 'push' || 
+      (github.event_name == 'pull_request' && (
+        github.actor != 'dependabot[bot]' || 
+        contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+      ))
 
     steps:
       - uses: actions/checkout@v4
@@ -34,3 +45,5 @@ jobs:
           projectName: blog
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          # For pull requests, deploy to preview branch
+          branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- Cloudflare Pages へのブランチデプロイメント機能を実装
- dependabot PR の条件付きデプロイメントに対応
- `deploy-preview` ラベルによる手動制御機能を追加

## Changes
- `.github/workflows/deploy-cloudflare.yml` を更新:
  - PR イベントでのトリガーを追加
  - dependabot PR はデフォルトでスキップ
  - `deploy-preview` ラベルが付いた場合はデプロイ実行
  - ブランチ名パラメータを追加してプレビューデプロイメントを有効化

## How it works
1. **通常のPR**: 自動的にプレビューデプロイメントが作成される
2. **dependabot PR**: デフォルトではプレビューデプロイメントなし
3. **dependabot PR + `deploy-preview` ラベル**: プレビューデプロイメントが作成される

## Test plan
- [ ] このPRでプレビューデプロイメントが作成されることを確認
- [ ] dependabot PRでデフォルトでデプロイされないことを確認
- [ ] dependabot PRに `deploy-preview` ラベルを追加するとデプロイされることを確認

Fixes #811

🤖 Generated with [Claude Code](https://claude.ai/code)