### PR TITLE
fix: CIワークフローにpull_requestトリガーを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - "**"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- CIワークフローに`pull_request`トリガーを追加
- これにより、E2E Test Status Managementワークフローが正しく動作するようになります

## 背景
#815 でE2E Test Status Managementワークフローを追加しましたが、CIワークフローが`push`イベントでのみ動作していたため、`workflow_run`イベントの条件（`github.event.workflow_run.event == 'pull_request'`）を満たさず、ステータス管理が機能していませんでした。

## 変更内容
`.github/workflows/ci.yml`に`pull_request`トリガーを追加：
```yaml
on:
  push:
    branches:
      - "**"
  pull_request:
    branches:
      - "**"
```

## Test plan
- [ ] このPRでCIワークフローが`pull_request`イベントで実行されることを確認
- [ ] E2E Test Status Managementワークフローが正しくトリガーされることを確認
- [ ] E2Eテストが失敗した場合、ステータスがpending（イエロー）になることを確認

Related to #814, #815

🤖 Generated with [Claude Code](https://claude.ai/code)