### PR TITLE
fix: ブランチデプロイはブログに関係あるファイルへの変更だけで実行する

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,24 +1,26 @@
 name: Deploy to Cloudflare Pages
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
     types: [opened, synchronize, labeled, unlabeled]
+    paths:
+      - "src/**"
+      - "public/**"
+      - "package.json"
+      - "package-lock.json"
+      - "astro.config.mjs"
+      - "tsconfig.json"
+      - ".node-version"
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Deploy if: push to main OR (PR and (not dependabot OR has deploy-preview label))
+    # Deploy if: (not dependabot OR has deploy-preview label)
     if: |
-      github.event_name == 'push' || 
-      (github.event_name == 'pull_request' && (
-        github.actor != 'dependabot[bot]' || 
-        contains(github.event.pull_request.labels.*.name, 'deploy-preview')
-      ))
+      github.actor != 'dependabot[bot]' || 
+      contains(github.event.pull_request.labels.*.name, 'deploy-preview')
 
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +52,6 @@ jobs:
           branch: ${{ github.head_ref || github.ref_name }}
 
       - name: Comment PR with deployment URL
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- ブランチデプロイ（deploy-cloudflare.yml）にパスフィルターを追加し、ブログに関連するファイルが変更された場合のみ実行されるようにしました
- pushイベントトリガーを削除し、PRのみでデプロイが実行されるようにしました
- 条件文を簡略化し、不要なチェックを削除しました

## Changes
- `src/**`、`public/**`、`package.json`、`package-lock.json`、`astro.config.mjs`、`tsconfig.json`、`.node-version` のいずれかが変更された場合のみデプロイを実行
- YAMLファイルなど、ブログに関係のないファイルのみの変更ではデプロイは実行されません

## Related Issue
Fixes #820

## Test plan
- [ ] PRを作成してもworkflowが実行されないことを確認（パスフィルターに該当しないファイルのみの変更）
- [ ] ブログ関連ファイルを変更した場合はworkflowが実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)